### PR TITLE
fixed password encryption bug

### DIFF
--- a/db/migrate/20191126082448_create_admins.rb
+++ b/db/migrate/20191126082448_create_admins.rb
@@ -2,7 +2,10 @@ class CreateAdmins < ActiveRecord::Migration[5.2]
   def change
     create_table :admins do |t|
       t.string :name
-      t.string :password
+      t.string :password_digest
+
+      t.timestamps
     end
+    add_index :admins, :name, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_26_005734) do
+ActiveRecord::Schema.define(version: 2019_11_26_082448) do
 
   create_table "admins", force: :cascade do |t|
+    t.string "name"
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name"
+    t.index ["name"], name: "index_admins_on_name", unique: true
   end
 
   create_table "certifications", force: :cascade do |t|


### PR DESCRIPTION
Fixed the bug caused by "password_digest" column of the admins table. 
The user passwords should not be directly saved on the database due to security issues so the admins table should only have "password_digest" as a column.
The bug was in the migration file where the column was named as "password" instead of "password_digest"

After pulling please do:
rake db:migration:reset
rails server
