### PR TITLE
Address field in vendor page redirects to map

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -1,5 +1,5 @@
 function initMap() {
-  var center = {lat: 37.868490, lng: -122.260410};
+  var center = gon.center;
   var locations = gon.vendor_list;
 
   var map = new google.maps.Map(document.getElementById('map'), {

--- a/app/controllers/my_vendors_controller.rb
+++ b/app/controllers/my_vendors_controller.rb
@@ -107,6 +107,17 @@ class MyVendorsController < ApplicationController
 	  	map_locations << vendor_info
   	end
   	
+  	if params[:id] != nil then
+  		vendor = MyVendor.find(params[:id])
+  		if (vendor.geocoded?) then
+			gon.center = {lat: vendor.latitude, lng: vendor.longitude}
+  		else
+			gon.center = {lat: 37.868490, lng: -122.260410}
+  		end
+  	else
+  		gon.center = {lat: 37.868490, lng: -122.260410}
+  	end
+  	
   	gon.vendor_list = map_locations
   end
 

--- a/app/views/my_vendors/show.html.haml
+++ b/app/views/my_vendors/show.html.haml
@@ -5,7 +5,7 @@
       = @vendor.name
       - if not @vendor.address.empty?
         #addr
-          = @vendor.address
+          = link_to @vendor.address, map_my_vendors_path(id: @vendor.id)
     #socialButtons
       = render 'details_social_buttons'
   -##tags


### PR DESCRIPTION
Clicking on the address field on the vendor page redirects to the map.
If the address is geocoded, the map will be centered on the address. If it isn't geocoded, the map will be centered on BSFC.